### PR TITLE
[docs] add Unicode::LineBreak under Line Breaking

### DIFF
--- a/lib/Text/Table/Manifold.pm
+++ b/lib/Text/Table/Manifold.pm
@@ -1779,6 +1779,8 @@ L<Text::Wrap>
 
 L<Text::WrapI18N>
 
+L<Unicode::LineBreak>
+
 =head1 Machine-Readable Change Log
 
 The file Changes was converted into Changelog.ini by L<Module::Metadata::Changes>.


### PR DESCRIPTION
[Unicode::LineBreak](https://metacpan.org/pod/Unicode::LineBreak) implements the [Unicode Line Breaking Algorithm (UAX #14)](http://unicode.org/reports/tr14/) and is the best Unicode-compatible line breaking solution on the CPAN, so it would be great to add to the _Line Breaking_ section.

Also, although not included in this PR, UAX #14 could be a good addition to the Unicode-related paragraph under _Embedded newlines_.
