### PR TITLE
try using String::TtyLength::tty_width() to calc widths of strings

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
 Revision history for Perl extension Text::Table::Manifold.
 
+1.01_01 2020-09-19 NEILB
+    - Developer release to test switching to String::TtyLength's tty_width()
+      for calculating width of strings. Added test case with wide text.
+
 1.01  2018-11-22:09:55:00
 	- Update pre-reqs for deal with test failures for CPAN Testers.
 	- Adopt new repo structure. For details, see

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,7 @@ my(%params) =
 		'Scalar::Util'					=> 1.50,
 		'strict'						=> 0,
 		'Types::Standard'				=> 1.000004,
-		'Unicode::GCString'				=> 2013.10,
+		'String::TtyLength'				=> 0.02,
 		'utf8'							=> 0,
 		'warnings'						=> 0,
 	},

--- a/lib/Text/Table/Manifold.pm
+++ b/lib/Text/Table/Manifold.pm
@@ -64,7 +64,7 @@ use Moo;
 
 use Types::Standard qw/Any ArrayRef HashRef Int Str/;
 
-use Unicode::GCString;
+use String::TtyLength 0.02 qw/ tty_width /;
 
 has alignment =>
 (
@@ -194,7 +194,7 @@ has widths =>
 	required => 0,
 );
 
-our $VERSION = '1.01';
+our $VERSION = '1.01_01';
 
 # ------------------------------------------------
 
@@ -202,7 +202,7 @@ sub _align_to_center
 {
 	my($self, $s, $width, $padding) = @_;
 	$s           ||= '';
-	my($s_width) = Unicode::GCString -> new($s) -> chars;
+	my($s_width) = tty_width($s);
 	my($left)    = int( ($width - $s_width) / 2);
 	my($right)   = $width - $s_width - $left;
 
@@ -216,7 +216,7 @@ sub _align_to_left
 {
 	my($self, $s, $width, $padding) = @_;
 	$s           ||= '';
-	my($s_width) = Unicode::GCString -> new($s || '') -> chars;
+	my($s_width) = tty_width($s);
 	my($right)   = $width - $s_width;
 
 	return (' ' x $padding) . $s . (' ' x ($right + $padding) );
@@ -229,7 +229,7 @@ sub _align_to_right
 {
 	my($self, $s, $width, $padding) = @_;
 	$s           ||= '';
-	my($s_width) = Unicode::GCString -> new($s || '') -> chars;
+	my($s_width) = tty_width($s);
 	my($left)    = $width - $s_width;
 
 	return (' ' x ($left + $padding) ) . $s . (' ' x $padding);
@@ -256,7 +256,7 @@ sub _clean_data
 		{
 			$s = $$data[$row][$column];
 			$s = defined($s)
-					? (length($s) == 0) # Unicode::GCString should not be necessary here.
+					? (length($s) == 0) # tty_width() should not be necessary here.
 						? ($empty == empty_as_minus)
 							? '-'
 							: ($empty == empty_as_text)
@@ -568,7 +568,7 @@ sub _gather_statistics
 			push @column, $$data[$row][$column];
 		}
 
-		push @max_widths, max map{Unicode::GCString -> new($_ || '') -> chars} @column;
+		push @max_widths, max map{ tty_width($_) } @column;
 	}
 
 	$self -> widths(\@max_widths);
@@ -1779,8 +1779,7 @@ L<Text::Wrap>
 
 L<Text::WrapI18N>
 
-L<Unicode::LineBreak>. The distro also includes L<Unicode::GCString>, which I use already in
-Text::Table::Manifold.
+L<Unicode::LineBreak>.
 
 L<UNICODE LINE BREAKING ALGORITHM|http://unicode.org/reports/tr14/>
 

--- a/t/00.versions.t
+++ b/t/00.versions.t
@@ -17,7 +17,7 @@ use Moo;
 use Scalar::Util;
 use strict;
 use Types::Standard;
-use Unicode::GCString;
+use String::TtyLength 0.02;
 use utf8;
 use warnings;
 
@@ -35,7 +35,7 @@ my(@modules) = qw
 	Scalar::Util
 	strict
 	Types::Standard
-	Unicode::GCString
+	String::TtyLength
 	utf8
 	warnings
 /;

--- a/t/wide-characters.t
+++ b/t/wide-characters.t
@@ -1,0 +1,49 @@
+#!perl
+
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Text::Table::Manifold;
+
+my @rows1 = (
+    ["こんにちは", "blah", "blah"],
+    ["smock", "blah", "blah"],
+    ["apple", "blah", "blah"],
+);
+
+my @rows2 = (
+    ["😄😄", "ac", "ae"],
+    ["aa", "😄😄", "ef"],
+    ["ab", "ad", "😄😄"],
+);
+
+table_is(\@rows1, <<"END_TABLE1", "double-width hiragana");
++----------+----+----+
+|          |    |    |
++----------+----+----+
+|こんにちは|blah|blah|
+|  smock   |blah|blah|
+|  apple   |blah|blah|
++----------+----+----+
+END_TABLE1
+
+table_is(\@rows2, <<"END_TABLE2", "double-width emoji");
++----+----+----+
+|    |    |    |
++----+----+----+
+|😄😄| ac | ae |
+| aa |😄😄| ef |
+| ab | ad |😄😄|
++----+----+----+
+END_TABLE2
+
+done_testing;
+
+sub table_is
+{
+    my ($rowsref, $expected, $label) = @_;
+    my $table  = Text::Table::Manifold->new(data => $rowsref);
+    my $result = join("\n", @{ $table->render })."\n";
+    is($result, $expected, $label);
+}


### PR DESCRIPTION
Hi Ron,

This changes the module to use String::TtyLength to calculate the width of strings, rather than Unicode::GCString.
Neither module gets it right all of the time, but String::TtyLength gets most common emojis right.

I did a developer release, which came out green across the board: [CPAN Testers Matrix](http://matrix.cpantesters.org/?dist=Text-Table-Manifold%201.01_01).

Cheers,
Neil
